### PR TITLE
add checkboxes to longmcp when the number of answers is 2 or superior

### DIFF
--- a/R/webexercises_fns.R
+++ b/R/webexercises_fns.R
@@ -126,7 +126,7 @@ torf <- function(answer) {
 }
 
 
-#' Longer MCQs with Radio Buttons
+#' Longer MCQs with Radio Buttons and Checkboxes
 #'
 #' @param opts Vector of alternatives. The correct answer is the
 #'   element(s) of this vector named 'answer'.
@@ -136,7 +136,8 @@ torf <- function(answer) {
 #'   examples.
 #'
 #' @return A character string containing HTML code to create a set of
-#'   radio buttons.
+#'   radio buttons (if there is only one answer) or a set of 
+#'   checkboxes (if there is two answers or more).
 #' 
 #' @examples
 #' # What is a p-value?
@@ -150,21 +151,31 @@ torf <- function(answer) {
 #' longmcq(opts)
 #'
 #' @export
-longmcq <- function(opts) {
-  ix <- which(names(opts) == "answer")
-  if (length(ix) == 0) {
-    stop("The question has no correct answer")
-  }
+longmcq <- function (opts) {
+    ix <- which(names(opts) == "answer")
+    opts2 <- gsub("'", "&apos;", opts, fixed = TRUE)
+    
+   if (length(ix) == 0) {
+        stop("The question has no correct answer")
+    
+    } else if (length(ix) == 1) {
+    qname <- paste0("radio_", paste(sample(LETTERS, 10, 
+        T), collapse = ""))
+    options <- sprintf("<label><input type=\"radio\" autocomplete=\"off\" name=\"%s\" value=\"%s\"></input> <span>%s</span></label>", 
+        qname, names(opts), opts2)
+    paste0("<div class='webex-radiogroup' id='", qname, 
+        "'>", paste(options, collapse = ""), "</div>\n")
+    
+    } else { #lenght >= 2
+    qname <-
+    lapply(opts2,
+           function(element) paste0("check_",
+                                    paste(sample(LETTERS, 10, TRUE), collapse = "")))
+    options <- sprintf("<div class='webex-checkbox' id =\"%s\"><label><input type=\"checkbox\" name=\"%s\" value=\"%s\"> </input><span>%s</span></label> </div>\n", 
+       qname, qname, names(opts), opts2)
+    paste0(options, collapse = "")
+    }
 
-  opts2 <- gsub("\'", "&apos;", opts, fixed = TRUE)
-  
-  # make up a name to group them
-  qname <- paste0("radio_", paste(sample(LETTERS, 10, T), collapse = ""))
-  options <- sprintf('<label><input type="radio" autocomplete="off" name="%s" value="%s"></input> <span>%s</span></label>', qname, names(opts), opts2)
-  
-  paste0("<div class='webex-radiogroup' id='", qname, "'>", 
-         paste(options, collapse = ""), 
-         "</div>\n")
 }
 
 

--- a/inst/reports/default/webex.css
+++ b/inst/reports/default/webex.css
@@ -20,6 +20,22 @@
     background-color: #c0edc2;
     border-radius: 0.25em;
 }
+
+.webex-incorrect,
+.webex-checkbox label.webex-incorrect{
+    border: 2px dotted var(--pink);
+    background-color: #edaddd;
+    border-radius: 0.25em;
+}
+
+.webex-correct,
+.webex-checkbox label.webex-correct {
+    border: 2px solid var(--green);
+    background-color: #c0edc2;
+    border-radius: 0.25em;
+}
+
+
 /* styles for hidden solutions */
 .webex-solution {
     height: 2.5em;
@@ -55,6 +71,21 @@
 }
 
 .webex-radiogroup label input {
+  position: relative;
+  left: -1em;
+}
+
+.webex-checkbox label {
+  margin-left: 2em;
+  text-indent: -1em;
+  padding-left: 0.5em;
+  font-weight: 400;
+  display: block;
+  border: 2px solid rgba(255, 255, 255, 1);
+  border-radius: 0.25em;
+}
+
+.webex-checkbox label input {
   position: relative;
   left: -1em;
 }

--- a/inst/reports/default/webex.js
+++ b/inst/reports/default/webex.js
@@ -8,9 +8,10 @@ update_total_correct = function() {
     var correct = document.getElementsByClassName("webex-correct").length;
     var solvemes = document.getElementsByClassName("webex-solveme").length;
     var radiogroups = document.getElementsByClassName("webex-radiogroup").length;
+    var checkboxes = document.getElementsByClassName("webex-checkbox").length;
     var selects = document.getElementsByClassName("webex-select").length;
     
-    t.innerHTML = correct + " of " + (solvemes + radiogroups + selects) + " correct";
+    t.innerHTML = correct + " of " + (solvemes + radiogroups + checkboxes + selects) + " correct";
   }
 }
 
@@ -99,6 +100,7 @@ radiogroups_func = function(e) {
   var cl = checked_button.parentElement.classList;
   var labels = checked_button.parentElement.parentElement.children;
   
+  
   /* get rid of styles */
   for (i = 0; i < labels.length; i++) {
     labels[i].classList.remove("webex-incorrect");
@@ -112,6 +114,31 @@ radiogroups_func = function(e) {
     cl.add("webex-incorrect");
   }
   
+  update_total_correct();
+}
+
+/* function for checking checkboxes answers */
+checkboxes_func = function(e) {
+  console.log("webex: check checkboxes");
+
+  var current_button = document.querySelector('input[name=' + this.id + ']');
+  var cl = current_button.parentElement.classList;
+  /*var labels = current_button.parentElement.parentElement.children;
+  labels.style.fontWeight = 'normal';*/
+
+/* add style when checked, remove when unchecked */
+  if (current_button.checked) {
+        if (current_button.value == "answer") {
+      cl.add("webex-correct");
+    } else {
+      cl.add("webex-incorrect");
+    }
+    
+  } else {
+     cl.remove("webex-incorrect");
+   cl.remove("webex-correct");
+  }
+
   update_total_correct();
 }
 
@@ -158,6 +185,18 @@ window.onload = function() {
   for (var i = 0; i < radiogroups.length; i++) {
     radiogroups[i].onchange = radiogroups_func;
   }
+  
+    /* set up checkboxes */
+  var checkboxes = document.getElementsByClassName("webex-checkbox");
+  
+  for (var i = 0; i < checkboxes.length; i++) {
+    checkboxes[i].onchange = checkboxes_func;
+  }
+
+  
+  
+
+
   
   /* set up selects */
   var selects = document.getElementsByClassName("webex-select");


### PR DESCRIPTION
Thanks for the package, it’s very useful for me since in want exercises in html without using shiny’s big machine. My courses relies heavily on MCQ with multiples answers, and then I made changes to use checkboxes instead of radio buttons (with colors for selected boxes). Pull if you find it’s worthwhile, dismiss otherwise ! 