### PR TITLE
allow decimal comma for numeric  with tolerance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # webexercises (development version)
 
+* allow decimal comma (in addition to decimal point) for numeric `fitb()` with tolerance
+
 # webexercises 1.1.0
 
 * quarto support (`create_quarto_doc()` and `add_to_quarto()`)

--- a/docs/articles/webexercises.html
+++ b/docs/articles/webexercises.html
@@ -499,6 +499,7 @@ solveme_func = function(e) {
 
   // match numeric answers within a specified tolerance
   if(this.dataset.tol > 0){
+    my_answer = my_answer.replace(/,/g, '.'); //also allow decimal comma
     var tol = JSON.parse(this.dataset.tol);
     var matches = real_answers.map(x => Math.abs(x - my_answer) < tol)
     if (matches.reduce((a, b) => a + b, 0) > 0) {

--- a/docs/extra.js
+++ b/docs/extra.js
@@ -47,6 +47,7 @@ solveme_func = function(e) {
 
   // match numeric answers within a specified tolerance
   if(this.dataset.tol > 0){
+    my_answer = my_answer.replace(/,/g, '.'); //also allow decimal comma
     var tol = JSON.parse(this.dataset.tol);
     var matches = real_answers.map(x => Math.abs(x - my_answer) < tol)
     if (matches.reduce((a, b) => a + b, 0) > 0) {

--- a/inst/reports/default/webex.js
+++ b/inst/reports/default/webex.js
@@ -69,6 +69,7 @@ solveme_func = function(e) {
 
   // match numeric answers within a specified tolerance
   if(this.dataset.tol > 0){
+    my_answer = my_answer.replace(/,/g, '.'); //also allow decimal comma
     var tol = JSON.parse(this.dataset.tol);
     var matches = real_answers.map(x => Math.abs(x - my_answer) < tol)
     if (matches.reduce((a, b) => a + b, 0) > 0) {

--- a/inst/rmarkdown/templates/webexercises/skeleton/skeleton.html
+++ b/inst/rmarkdown/templates/webexercises/skeleton/skeleton.html
@@ -707,6 +707,7 @@ solveme_func = function(e) {
 
   // match numeric answers within a specified tolerance
   if(this.dataset.tol > 0){
+    my_answer = my_answer.replace(/,/g, '.'); //also allow decimal comma
     var tol = JSON.parse(this.dataset.tol);
     var matches = real_answers.map(x => Math.abs(x - my_answer) < tol)
     if (matches.reduce((a, b) => a + b, 0) > 0) {


### PR DESCRIPTION
I'm using `webexercises` for my [interactive math exercises](https://www.mathe4wiwi.org/training/). As the exercises is in German many students use a [decimal comma rather than a decimal point](https://en.wikipedia.org/wiki/Decimal_separator). So to allow for this as being correct I have adapted the `webex.js` code to replace `,` with `.` prior to checking the tolerance:

```
my_answer = my_answer.replace(/,/g, '.');
```

As this is only done if there is a tolerance, I felt that the replacement could be done without further conditions (e.g., adding a class). This is also the behavior of most learning management systems like Moodle etc.

If there is no tolerance, then the answer is likely an integer anyway, so I have not tried to address that case. Not sure whether that might be relevant for some use cases.