### PR TITLE
Modified fct longmcq so that it correctly handle mathjax expression when using "cat" to output content of longmcq

### DIFF
--- a/R/webexercises_fns.R
+++ b/R/webexercises_fns.R
@@ -84,6 +84,11 @@ fitb <- function(answer,
          html, pdf)
 }
 
+
+
+
+
+
 #' Create a multiple-choice question
 #'
 #' @param opts Vector of alternatives. The correct answer is the
@@ -120,10 +125,13 @@ mcq <- function(opts) {
   # check type of knitting
   out_fmt <- knitr::opts_knit$get("out.format")
   pandoc_to <- knitr::opts_knit$get("rmarkdown.pandoc.to")
+
   ifelse((is.null(out_fmt) & is.null(pandoc_to)) ||
            isTRUE(out_fmt == "html") ||
            isTRUE(pandoc_to == "html"),
          html, pdf)
+
+
 }
 
 #' Create a true-or-false question
@@ -157,6 +165,15 @@ torf <- function(answer) {
          mcq(opts), "TRUE / FALSE")
 }
 
+# Function that add backslashes when mathjax is identified in the possible answers so that when printing using cat, it render correctly.
+# This ensure that when you print the output of longmcq  using "cat", the math are correctly displayed as "\" is an escape character in R.
+add_backslashes <- function(input_string) {
+  # Use regular expressions to replace single backslashes with double backslashes
+  result <- gsub("\\\\", "\\\\\\\\", input_string)
+  return(result)
+}
+
+
 
 #' Longer MCQs with Radio Buttons
 #'
@@ -183,6 +200,7 @@ torf <- function(answer) {
 #'
 #' @export
 longmcq <- function(opts) {
+
   ix <- which(names(opts) == "answer")
   if (length(ix) == 0) {
     stop("The question has no correct answer")
@@ -206,10 +224,10 @@ longmcq <- function(opts) {
   # check type of knitting
   out_fmt <- knitr::opts_knit$get("out.format")
   pandoc_to <- knitr::opts_knit$get("rmarkdown.pandoc.to")
-  ifelse((is.null(out_fmt) & is.null(pandoc_to)) ||
-           isTRUE(out_fmt == "html") ||
-           isTRUE(pandoc_to == "html"),
-         html, pdf)
+  add_backslashes(ifelse((is.null(out_fmt) & is.null(pandoc_to)) ||
+                           isTRUE(out_fmt == "html") ||
+                           isTRUE(pandoc_to == "html"),
+                         html, pdf))
 }
 
 


### PR DESCRIPTION
Hi,

Currently, the fct `longmcq()` do not support math expression when used in a `quarto` website.

Indeed, consider for example the following choices:

```
 opts <- c(
     "\\(\\frac{1}{10}\\)",
     "\\(\\frac{3}{10}\\)",
     "\\(\\frac{2}{5}\\)",
     answer =     "\\( \\frac{52}{100}\\)"
 )
```
Running `longmcq()` on that vector returns:

``` 
> longmcq(opts)
[1] "<div class='webex-radiogroup' id='radio_XEJMHGSWZF'><label><input type=\"radio\" autocomplete=\"off\" name=\"radio_XEJMHGSWZF\" value=\"\"></input> <span>\\(\\frac{1}{10}\\)</span></label><label><input type=\"radio\" autocomplete=\"off\" name=\"radio_XEJMHGSWZF\" value=\"\"></input> <span>\\(\\frac{3}{10}\\)</span></label><label><input type=\"radio\" autocomplete=\"off\" name=\"radio_XEJMHGSWZF\" value=\"\"></input> <span>\\(\\frac{2}{5}\\)</span></label><label><input type=\"radio\" autocomplete=\"off\" name=\"radio_XEJMHGSWZF\" value=\"answer\"></input> <span>\\( \\frac{52}{100}\\)</span></label></div>\n"
```

However, when using `cat()` on that object, you will get:

```
> cat(longmcq(opts))
<div class='webex-radiogroup' id='radio_XRQNLWVXID'><label><input type="radio" autocomplete="off" name="radio_XRQNLWVXID" value=""></input> <span>\(\frac{1}{10}\)</span></label><label><input type="radio" autocomplete="off" name="radio_XRQNLWVXID" value=""></input> <span>\(\frac{3}{10}\)</span></label><label><input type="radio" autocomplete="off" name="radio_XRQNLWVXID" value=""></input> <span>\(\frac{2}{5}\)</span></label><label><input type="radio" autocomplete="off" name="radio_XRQNLWVXID" value="answer"></input> <span>\( \frac{52}{100}\)</span></label></div>

```

and so this will not render correctly in your `quarto` website using mathjax or katex.

This PR fix this by adding backslashes when these escapes characters are recognized and allowing to use `longmcq()` and printing its content using `cat()` and correctly rendering math expression in a `quarto` website.

See an example at : https://intro-statistique.netlify.app

Best
